### PR TITLE
Fix analytics bug tracking the wrong cards

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -122,7 +122,7 @@
       <!-- Amount of visitors - 1 month -->
       <div class="container">
         <div class="mb-5 row justify-content-center">
-          <div id="pricing-cards" class="col-lg-12">
+          <div class="col-lg-12">
             <div class="row row-grid">
               <div class="col-lg-12">
                 <div class="card card-lift--hover shadow border-0">
@@ -160,7 +160,7 @@
 
         <!-- Number of Visits - 24h -->
         <div class="mb-5 row justify-content-center">
-          <div id="pricing-cards" class="col-lg-12">
+          <div class="col-lg-12">
             <div class="row row-grid">
               <div class="col-lg-12">
                 <div class="card card-lift--hover shadow border-0">
@@ -197,7 +197,7 @@
 
         <!-- Begins new card copy + paste -->
         <div class="mb-5 row justify-content-center">
-          <div id="pricing-cards" class="col-lg-12">
+          <div class="col-lg-12">
             <div class="row row-grid">
               <div class="col-lg-12">
                 <div class="card card-lift--hover shadow border-0">
@@ -235,7 +235,7 @@
 
         <!-- Begins new card copy + paste -->
         <div class="mb-5 row justify-content-center">
-          <div id="pricing-cards" class="col-lg-12">
+          <div class="col-lg-12">
             <div class="row row-grid">
               <div class="col-lg-12">
                 <div class="card card-lift--hover shadow border-0">
@@ -272,7 +272,7 @@
 
         <!-- Begins new card copy + paste -->
         <div class="mb-5 row justify-content-center">
-          <div id="pricing-cards" class="col-lg-12">
+          <div class="col-lg-12">
             <div class="row row-grid">
               <div class="col-lg-12">
                 <div class="card card-lift--hover shadow border-0">
@@ -309,7 +309,7 @@
 
         <!-- Begins new card copy + paste -->
         <div class="mb-5 row justify-content-center">
-          <div id="pricing-cards" class="col-lg-12">
+          <div class="col-lg-12">
             <div class="row row-grid">
               <div class="col-lg-12">
                 <div class="card card-lift--hover shadow border-0">
@@ -346,7 +346,7 @@
 
         <!-- Begins new card copy + paste -->
         <div class="mb-5 row justify-content-center">
-          <div id="pricing-cards" class="col-lg-12">
+          <div class="col-lg-12">
             <div class="row row-grid">
               <div class="col-lg-12">
                 <div class="card card-lift--hover shadow border-0">


### PR DESCRIPTION
The analytics page has chart cards but the id is set to pricing-cards,
causing segment to track these cards which don't need to be tracked.